### PR TITLE
Remove autoselect behaviour from decrypted text

### DIFF
--- a/src/views/DecryptView.vue
+++ b/src/views/DecryptView.vue
@@ -35,7 +35,7 @@ watch(privateKeyLocked, doDecrypt)
     </div>
     <div>
       <h3>Decrypted Message</h3>
-      <textarea v-model="plainTextarea" @click="$event.target.select()" readonly></textarea>
+      <textarea v-model="plainTextarea" readonly></textarea>
     </div>
   </div>
 </template>


### PR DESCRIPTION
This behaviour is annoying, and only ciphertext needs to be transported as a monolithic entity.